### PR TITLE
[add] enable/disable cloudwatch alarm

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,7 +10,7 @@
   revision = "1fca145dffbcaa8fe914309b1ec0cfc67500fe61"
 
 [[projects]]
-  digest = "1:f2e2ee88002f421ca77ada41cc19c8a864b3c7afa0dafd27a696bf6b92eefc48"
+  digest = "1:71b928118dc3168608c145b8a0030468b0e7aeb687ab09e3c77ada7fe3ec6c12"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -38,7 +38,9 @@
     "private/protocol/query",
     "private/protocol/query/queryutil",
     "private/protocol/rest",
+    "private/protocol/restxml",
     "private/protocol/xml/xmlutil",
+    "service/cloudfront",
     "service/cloudwatch",
     "service/cloudwatchlogs",
     "service/ecs",
@@ -171,6 +173,7 @@
   input-imports = [
     "github.com/aws/aws-sdk-go/aws",
     "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/cloudfront",
     "github.com/aws/aws-sdk-go/service/cloudwatch",
     "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
     "github.com/aws/aws-sdk-go/service/ecs",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -3,11 +3,14 @@
 
 [[projects]]
   branch = "master"
+  digest = "1:9fd3a6ab34bb103ba228eefd044d3f9aa476237ea95a46d12e8cccd3abf3fea2"
   name = "github.com/armon/go-radix"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1fca145dffbcaa8fe914309b1ec0cfc67500fe61"
 
 [[projects]]
+  digest = "1:f2e2ee88002f421ca77ada41cc19c8a864b3c7afa0dafd27a696bf6b92eefc48"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -40,96 +43,142 @@
     "service/cloudwatchlogs",
     "service/ecs",
     "service/sns",
-    "service/sts"
+    "service/sts",
   ]
+  pruneopts = "UT"
   revision = "9b0098a71f6d4d473a26ec8ad3c2feaac6eb1da6"
   version = "v1.13.32"
 
 [[projects]]
+  digest = "1:1343a2963481a305ca4d051e84bc2abd16b601ee22ed324f8d605de1adb291b0"
   name = "github.com/bgentry/speakeasy"
   packages = ["."]
+  pruneopts = "UT"
   revision = "4aabc24848ce5fd31929f7d1e4ea74d3709c14cd"
   version = "v0.1.0"
 
 [[projects]]
+  digest = "1:4bb94bb2d837b5c7489d9e5e1fcffbc81fa1cb43024cbb4fe827787378f01e3b"
   name = "github.com/fatih/color"
   packages = ["."]
+  pruneopts = "UT"
   revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
   version = "v1.6.0"
 
 [[projects]]
+  digest = "1:ad12727c184fc7e33768f5fe239d8f767a3b60264541067ac2f23b9aca013e06"
   name = "github.com/go-ini/ini"
   packages = ["."]
+  pruneopts = "UT"
   revision = "ace140f73450505f33e8b8418216792275ae82a7"
   version = "v1.35.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:07671f8997086ed115824d1974507d2b147d1e0463675ea5dbf3be89b1c2c563"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
 
 [[projects]]
   branch = "master"
+  digest = "1:e5048c5da80697be2fcdecc944e29d2999e01fd7f48b643168443209779f3463"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b7773ae218740a7be65057fc60b366a49b538a44"
 
 [[projects]]
+  branch = "master"
+  digest = "1:6ff03494445ac7b3f634dbe067e603ca7c8d83f21fd776316e436e01d66e1727"
+  name = "github.com/howtv/go-awsctr"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "7436a716c567359ed586afded2e72d6361d5df26"
+
+[[projects]]
+  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0b12d6b5"
 
 [[projects]]
   branch = "master"
+  digest = "1:70107cf7ee5eb9e3c3dabe65bcb220bff22ee42e32d9b7fca988e16b8727cacc"
   name = "github.com/juju/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c7d06af17c68cd34c835053720b21f6549d9b0ee"
 
 [[projects]]
+  digest = "1:16dd6b893b78a50564cdde1d9f7ea67224dece11bb0886bd882f1dc3dc1d440d"
   name = "github.com/k0kubun/pp"
   packages = ["."]
+  pruneopts = "UT"
   revision = "027a6d1765d673d337e687394dbe780dd64e2a1e"
   version = "v2.3.0"
 
 [[projects]]
+  digest = "1:c658e84ad3916da105a761660dcaeb01e63416c8ec7bc62256a9b411a05fcd67"
   name = "github.com/mattn/go-colorable"
   packages = ["."]
+  pruneopts = "UT"
   revision = "167de6bfdfba052fa6b2d3664c8f5272e23c9072"
   version = "v0.0.9"
 
 [[projects]]
+  digest = "1:d4d17353dbd05cb52a2a52b7fe1771883b682806f68db442b436294926bbfafb"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
   version = "v0.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:0fbbd0f1fa0d71a357594b0f40b25458eccbe1809d95843e81129b93e7a7b1cb"
   name = "github.com/mitchellh/cli"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c48282d14eba4b0817ddef3f832ff8d13851aefd"
 
 [[projects]]
+  digest = "1:4d76324ccff5546792b4274c5fe1639bc5983c533c85d1b4be2168d57daabdf0"
   name = "github.com/posener/complete"
   packages = [
     ".",
     "cmd",
     "cmd/install",
-    "match"
+    "match",
   ]
+  pruneopts = "UT"
   revision = "98eb9847f27ba2008d380a32c98be474dea55bdf"
   version = "v1.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:f45590247caf7c95fcbdbf732384e751d67505486000ecf4524a33bdad90fada"
   name = "golang.org/x/sys"
   packages = ["unix"]
+  pruneopts = "UT"
   revision = "2281fa97ef7b0c26324634d5a22f04babdac8713"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "f7b7c9b4043bce128f43092de0412d8675b97bd676a56c32e6c5d8efe320d0e3"
+  input-imports = [
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/cloudwatch",
+    "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
+    "github.com/aws/aws-sdk-go/service/ecs",
+    "github.com/aws/aws-sdk-go/service/sns",
+    "github.com/howtv/go-awsctr",
+    "github.com/juju/errors",
+    "github.com/k0kubun/pp",
+    "github.com/mitchellh/cli",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,15 +2,15 @@
 
 
 [[projects]]
-  branch = "master"
-  digest = "1:9fd3a6ab34bb103ba228eefd044d3f9aa476237ea95a46d12e8cccd3abf3fea2"
+  digest = "1:c47f4964978e211c6e566596ec6246c329912ea92e9bb99c00798bb4564c5b09"
   name = "github.com/armon/go-radix"
   packages = ["."]
   pruneopts = "UT"
-  revision = "1fca145dffbcaa8fe914309b1ec0cfc67500fe61"
+  revision = "1a2de0c21c94309923825da3df33a4381872c795"
+  version = "v1.0.0"
 
 [[projects]]
-  digest = "1:71b928118dc3168608c145b8a0030468b0e7aeb687ab09e3c77ada7fe3ec6c12"
+  digest = "1:4dcb66bb7ec658f66c50e3adb297c98f2ab55c0929b8d1eb2c7142242b04f538"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -23,6 +23,7 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
@@ -31,6 +32,7 @@
     "aws/signer/v4",
     "internal/sdkio",
     "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
     "private/protocol/json/jsonutil",
@@ -43,13 +45,14 @@
     "service/cloudfront",
     "service/cloudwatch",
     "service/cloudwatchlogs",
+    "service/codepipeline",
     "service/ecs",
     "service/sns",
     "service/sts",
   ]
   pruneopts = "UT"
-  revision = "9b0098a71f6d4d473a26ec8ad3c2feaac6eb1da6"
-  version = "v1.13.32"
+  revision = "bf8067ceb6e7f51e150c218972dccfeeed892b85"
+  version = "v1.15.54"
 
 [[projects]]
   digest = "1:1343a2963481a305ca4d051e84bc2abd16b601ee22ed324f8d605de1adb291b0"
@@ -60,36 +63,36 @@
   version = "v0.1.0"
 
 [[projects]]
-  digest = "1:4bb94bb2d837b5c7489d9e5e1fcffbc81fa1cb43024cbb4fe827787378f01e3b"
+  digest = "1:865079840386857c809b72ce300be7580cb50d3d3129ce11bf9aa6ca2bc1934a"
   name = "github.com/fatih/color"
   packages = ["."]
   pruneopts = "UT"
-  revision = "507f6050b8568533fb3f5504de8e5205fa62a114"
-  version = "v1.6.0"
+  revision = "5b77d2a35fb0ede96d138fc9a99f5c9b6aef11b4"
+  version = "v1.7.0"
 
 [[projects]]
-  digest = "1:ad12727c184fc7e33768f5fe239d8f767a3b60264541067ac2f23b9aca013e06"
+  digest = "1:b98e7574fc27ec166fb31195ec72c3bd0bffd73926d3612eb4c929bc5236f75b"
   name = "github.com/go-ini/ini"
   packages = ["."]
   pruneopts = "UT"
-  revision = "ace140f73450505f33e8b8418216792275ae82a7"
-  version = "v1.35.0"
+  revision = "7b294651033cd7d9e7f0d9ffa1b75ed1e198e737"
+  version = "v1.38.3"
 
 [[projects]]
-  branch = "master"
-  digest = "1:07671f8997086ed115824d1974507d2b147d1e0463675ea5dbf3be89b1c2c563"
+  digest = "1:0ade334594e69404d80d9d323445d2297ff8161637f9b2d347cc6973d2d6f05b"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
   pruneopts = "UT"
-  revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
+  revision = "8a6fb523712970c966eefc6b39ed2c5e74880354"
+  version = "v1.0.0"
 
 [[projects]]
-  branch = "master"
-  digest = "1:e5048c5da80697be2fcdecc944e29d2999e01fd7f48b643168443209779f3463"
+  digest = "1:f668349b83f7d779567c880550534addeca7ebadfdcf44b0b9c39be61864b4b7"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
   pruneopts = "UT"
-  revision = "b7773ae218740a7be65057fc60b366a49b538a44"
+  revision = "886a7fbe3eb1c874d46f623bfa70af45f425b3d1"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -108,11 +111,11 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:70107cf7ee5eb9e3c3dabe65bcb220bff22ee42e32d9b7fca988e16b8727cacc"
+  digest = "1:cdc32003a67007f608c767cfbea5b7a07ed7418ec9aed579707e3185086a6878"
   name = "github.com/juju/errors"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c7d06af17c68cd34c835053720b21f6549d9b0ee"
+  revision = "a4583d0a56eac4bdd939e38050d0c69abe0a9b41"
 
 [[projects]]
   digest = "1:16dd6b893b78a50564cdde1d9f7ea67224dece11bb0886bd882f1dc3dc1d440d"
@@ -131,23 +134,23 @@
   version = "v0.0.9"
 
 [[projects]]
-  digest = "1:d4d17353dbd05cb52a2a52b7fe1771883b682806f68db442b436294926bbfafb"
+  digest = "1:0981502f9816113c9c8c4ac301583841855c8cf4da8c72f696b3ebedf6d0e4e5"
   name = "github.com/mattn/go-isatty"
   packages = ["."]
   pruneopts = "UT"
-  revision = "0360b2af4f38e8d38c7fce2a9f4e702702d73a39"
-  version = "v0.0.3"
+  revision = "6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c"
+  version = "v0.0.4"
 
 [[projects]]
   branch = "master"
-  digest = "1:0fbbd0f1fa0d71a357594b0f40b25458eccbe1809d95843e81129b93e7a7b1cb"
+  digest = "1:dac0667a3fcdd4102a5da07abeddc89eb2f125b1e91af1ea9544c80eaff19c9a"
   name = "github.com/mitchellh/cli"
   packages = ["."]
   pruneopts = "UT"
-  revision = "c48282d14eba4b0817ddef3f832ff8d13851aefd"
+  revision = "3d22a244be8aa6fb16ac24af0e195c08b7d973aa"
 
 [[projects]]
-  digest = "1:4d76324ccff5546792b4274c5fe1639bc5983c533c85d1b4be2168d57daabdf0"
+  digest = "1:963772912b1d71f582a78a3f55a0e83bbd88777335a07a57cfbe0f01df2df06b"
   name = "github.com/posener/complete"
   packages = [
     ".",
@@ -156,16 +159,16 @@
     "match",
   ]
   pruneopts = "UT"
-  revision = "98eb9847f27ba2008d380a32c98be474dea55bdf"
-  version = "v1.1.1"
+  revision = "dcda3199365ca2a5f24aea4c42aa56f6a197d117"
+  version = "v1.1.2"
 
 [[projects]]
   branch = "master"
-  digest = "1:f45590247caf7c95fcbdbf732384e751d67505486000ecf4524a33bdad90fada"
+  digest = "1:0a40b0bdd57a93e741d8557465be3a2edeec408e9b6399586ad65bbe8e355796"
   name = "golang.org/x/sys"
   packages = ["unix"]
   pruneopts = "UT"
-  revision = "2281fa97ef7b0c26324634d5a22f04babdac8713"
+  revision = "fa43e7bc11baaae89f3f902b2b4d832b68234844"
 
 [solve-meta]
   analyzer-name = "dep"
@@ -176,6 +179,7 @@
     "github.com/aws/aws-sdk-go/service/cloudfront",
     "github.com/aws/aws-sdk-go/service/cloudwatch",
     "github.com/aws/aws-sdk-go/service/cloudwatchlogs",
+    "github.com/aws/aws-sdk-go/service/codepipeline",
     "github.com/aws/aws-sdk-go/service/ecs",
     "github.com/aws/aws-sdk-go/service/sns",
     "github.com/howtv/go-awsctr",

--- a/cloudfront.go
+++ b/cloudfront.go
@@ -40,18 +40,29 @@ type cloudFrontImpl struct {
 // aws cloudfront create-invalidation --distribution-id S11A16G5KZMEQD --paths /index.html /error.html
 func (c *cloudFrontImpl) Invalidate(iv InvalidateInfo) error {
 	path := aws.String(iv.Path)
+	var paths *cloudfront.Paths
+	paths = paths.SetQuantity(1)
+	paths = paths.SetItems([]*string{path})
+	if err := paths.Validate(); err != nil {
+		return err
+	}
+
 	unixTime := time.Now().Unix()
-	_, err := c.client.CreateInvalidation(&cloudfront.CreateInvalidationInput{
-		DistributionId: aws.String(iv.DistID),
-		InvalidationBatch: &cloudfront.InvalidationBatch{
-			CallerReference: aws.String(fmt.Sprint(unixTime)),
-			Paths: &cloudfront.Paths{
-				Items:    []*string{path},
-				Quantity: aws.Int64(1),
-			},
-		},
-	})
-	if err != nil {
+	var batch *cloudfront.InvalidationBatch
+	batch = batch.SetCallerReference(fmt.Sprint(unixTime))
+	batch = batch.SetPaths(paths)
+	if err := batch.Validate(); err != nil {
+		return err
+	}
+
+	var input *cloudfront.CreateInvalidationInput
+	input = input.SetDistributionId(iv.DistID)
+	input = input.SetInvalidationBatch(batch)
+	if err := input.Validate(); err != nil {
+		return err
+	}
+
+	if _, err := c.client.CreateInvalidation(input); err != nil {
 		return err
 	}
 

--- a/cloudfront.go
+++ b/cloudfront.go
@@ -1,0 +1,59 @@
+package awsctr
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudfront"
+)
+
+// InvalidateInfo -
+type InvalidateInfo struct {
+	DistID string
+	Path   string
+}
+
+// CloudFront -
+type CloudFront interface {
+	Invalidate(InvalidateInfo) error
+}
+
+// NewCloudFront -
+func NewCloudFront(sess *session.Session) CloudFront {
+	return &cloudFrontImpl{
+		client: cloudfront.New(sess),
+	}
+}
+
+type cloudFrontService interface {
+	CreateInvalidation(input *cloudfront.CreateInvalidationInput) (*cloudfront.CreateInvalidationOutput, error)
+}
+
+type cloudFrontImpl struct {
+	client cloudFrontService
+}
+
+// Invalidate -
+// cli sample:
+// aws cloudfront create-invalidation --distribution-id S11A16G5KZMEQD --paths /index.html /error.html
+func (c *cloudFrontImpl) Invalidate(iv InvalidateInfo) error {
+	path := aws.String(iv.Path)
+	unixTime := time.Now().Unix()
+	_, err := c.client.CreateInvalidation(&cloudfront.CreateInvalidationInput{
+		DistributionId: aws.String(iv.DistID),
+		InvalidationBatch: &cloudfront.InvalidationBatch{
+			CallerReference: aws.String(fmt.Sprint(unixTime)),
+			Paths: &cloudfront.Paths{
+				Items:    []*string{path},
+				Quantity: aws.Int64(1),
+			},
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cloudfront.go
+++ b/cloudfront.go
@@ -40,29 +40,29 @@ type cloudFrontImpl struct {
 // aws cloudfront create-invalidation --distribution-id S11A16G5KZMEQD --paths /index.html /error.html
 func (c *cloudFrontImpl) Invalidate(iv InvalidateInfo) error {
 	path := aws.String(iv.Path)
-	var paths *cloudfront.Paths
-	paths = paths.SetQuantity(1)
-	paths = paths.SetItems([]*string{path})
+	var paths cloudfront.Paths
+	paths = *paths.SetQuantity(1)
+	paths = *paths.SetItems([]*string{path})
 	if err := paths.Validate(); err != nil {
 		return err
 	}
 
 	unixTime := time.Now().Unix()
-	var batch *cloudfront.InvalidationBatch
-	batch = batch.SetCallerReference(fmt.Sprint(unixTime))
-	batch = batch.SetPaths(paths)
+	var batch cloudfront.InvalidationBatch
+	batch = *batch.SetCallerReference(fmt.Sprint(unixTime))
+	batch = *batch.SetPaths(&paths)
 	if err := batch.Validate(); err != nil {
 		return err
 	}
 
-	var input *cloudfront.CreateInvalidationInput
-	input = input.SetDistributionId(iv.DistID)
-	input = input.SetInvalidationBatch(batch)
+	var input cloudfront.CreateInvalidationInput
+	input = *input.SetDistributionId(iv.DistID)
+	input = *input.SetInvalidationBatch(&batch)
 	if err := input.Validate(); err != nil {
 		return err
 	}
 
-	if _, err := c.client.CreateInvalidation(input); err != nil {
+	if _, err := c.client.CreateInvalidation(&input); err != nil {
 		return err
 	}
 

--- a/cloudwatch.go
+++ b/cloudwatch.go
@@ -15,9 +15,16 @@ type CountMetricsInfo struct {
 	Value          float64
 }
 
+// AlarmInfo -
+type AlarmInfo struct {
+	Name string
+}
+
 // CloudWatch -
 type CloudWatch interface {
 	PutCountMetrics(CountMetricsInfo) error
+	AlarmOn(AlarmInfo) error
+	AlarmOff(AlarmInfo) error
 }
 
 // NewCloudWatch -
@@ -29,6 +36,8 @@ func NewCloudWatch(sess *session.Session) CloudWatch {
 
 type cloudWatchService interface {
 	PutMetricData(input *cloudwatch.PutMetricDataInput) (*cloudwatch.PutMetricDataOutput, error)
+	EnableAlarmActions(input *cloudwatch.EnableAlarmActionsInput) (*cloudwatch.EnableAlarmActionsOutput, error)
+	DisableAlarmActions(input *cloudwatch.DisableAlarmActionsInput) (*cloudwatch.DisableAlarmActionsOutput, error)
 }
 
 type cloudWatchImpl struct {
@@ -54,6 +63,38 @@ func (c *cloudWatchImpl) PutCountMetrics(info CountMetricsInfo) error {
 			},
 		},
 		Namespace: aws.String(info.NameSpace),
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AlarmOn -
+// cli sample:
+// aws cloudwatch enable-alarm-actions --alarm-names <value>
+func (c *cloudWatchImpl) AlarmOn(alarm AlarmInfo) error {
+	_, err := c.client.EnableAlarmActions(&cloudwatch.EnableAlarmActionsInput{
+		AlarmNames: []*string{
+			aws.String(alarm.Name),
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// AlarmOff -
+// cli sample:
+// aws cloudwatch disable-alarm-actions --alarm-names <value>
+func (c *cloudWatchImpl) AlarmOff(alarm AlarmInfo) error {
+	_, err := c.client.DisableAlarmActions(&cloudwatch.DisableAlarmActionsInput{
+		AlarmNames: []*string{
+			aws.String(alarm.Name),
+		},
 	})
 	if err != nil {
 		return err

--- a/codepipeline.go
+++ b/codepipeline.go
@@ -1,6 +1,7 @@
 package awsctr
 
 import (
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/codepipeline"
 )
@@ -36,7 +37,6 @@ type codePipelineImpl struct {
 // cli sample:
 // aws codepipeline put-job-success-result --job-id e930bc23-49f3-442d-8189-8c33889a1791
 func (c *codePipelineImpl) SendJobSuccess(job JobInfo) error {
-
 	var input codepipeline.PutJobSuccessResultInput
 	input = *input.SetJobId(job.ID)
 	if err := input.Validate(); err != nil {
@@ -56,6 +56,10 @@ func (c *codePipelineImpl) SendJobFailure(job JobInfo) error {
 
 	var input codepipeline.PutJobFailureResultInput
 	input = *input.SetJobId(job.ID)
+	input = *input.SetFailureDetails(&codepipeline.FailureDetails{
+		Message: aws.String("failed job"),
+		Type:    aws.String(codepipeline.FailureTypeJobFailed),
+	})
 	if err := input.Validate(); err != nil {
 		return err
 	}

--- a/codepipeline.go
+++ b/codepipeline.go
@@ -1,0 +1,68 @@
+package awsctr
+
+import (
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/codepipeline"
+)
+
+// JobInfo -
+type JobInfo struct {
+	ID        string
+	IsSuccess bool
+}
+
+// CodePipeline -
+type CodePipeline interface {
+	SendJobSuccess(JobInfo) error
+	SendJobFailure(JobInfo) error
+}
+
+// NewCodePipeline -
+func NewCodePipeline(sess *session.Session) CodePipeline {
+	return &codePipelineImpl{
+		client: codepipeline.New(sess),
+	}
+}
+
+type codePipelineService interface {
+	PutJobSuccessResult(input *codepipeline.PutJobSuccessResultInput) (*codepipeline.PutJobSuccessResultOutput, error)
+	PutJobFailureResult(input *codepipeline.PutJobFailureResultInput) (*codepipeline.PutJobFailureResultOutput, error)
+}
+
+type codePipelineImpl struct {
+	client codePipelineService
+}
+
+// SendJobSuccess -
+// cli sample:
+// aws codepipeline put-job-success-result --job-id e930bc23-49f3-442d-8189-8c33889a1791
+func (c *codePipelineImpl) SendJobSuccess(job JobInfo) error {
+
+	var input codepipeline.PutJobSuccessResultInput
+	input = *input.SetJobId(job.ID)
+	if err := input.Validate(); err != nil {
+		return err
+	}
+	if _, err := c.client.PutJobSuccessResult(&input); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// SendJobFailure -
+// cli sample:
+// aws codepipeline put-job-failure-result --job-id e930bc23-49f3-442d-8189-8c33889a1791
+func (c *codePipelineImpl) SendJobFailure(job JobInfo) error {
+
+	var input codepipeline.PutJobFailureResultInput
+	input = *input.SetJobId(job.ID)
+	if err := input.Validate(); err != nil {
+		return err
+	}
+	if _, err := c.client.PutJobFailureResult(&input); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/codepipeline.go
+++ b/codepipeline.go
@@ -7,8 +7,7 @@ import (
 
 // JobInfo -
 type JobInfo struct {
-	ID        string
-	IsSuccess bool
+	ID string
 }
 
 // CodePipeline -


### PR DESCRIPTION
* cloudwatchメトリクスのalarmをenable/disableする機能です。
* ユースケースとしては、定時間帯のみ監視除外したい場合にlambda + cloudwatch eventsと合わせて実行する、など。

* Codepipeline jobの実行結果を返す機能も追加。これもLambda内から返す時に使う想定。